### PR TITLE
Abstract away event parsing

### DIFF
--- a/lib/redfish_client/event_listener.rb
+++ b/lib/redfish_client/event_listener.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "json"
+require "uri"
+
+module RedfishClient
+  # EventListener class can be used to stream events from Redfish service. It
+  # is a thin wrapper around SSE listener that does the dirty work of
+  # splitting each event into its EventRecords and reporting them as separate
+  # events.
+  class EventListener
+    # Create new EventListener instance.
+    #
+    # @param sse_client [ServerSentEvents::Client] SSE client
+    def initialize(sse_client)
+      @sse_client = sse_client
+    end
+
+    # Stream events from redfish service.
+    #
+    # Events that this method yields are actually EventRecords, extracted from
+    # the actual Redfish Event.
+    def listen
+      @sse_client.listen do |event|
+        split_event_into_records(event).each { |r| yield(r) }
+      end
+    end
+
+    private
+
+    def split_event_into_records(event)
+      JSON.parse(event.data).fetch("Events", [])
+    end
+  end
+end

--- a/lib/redfish_client/root.rb
+++ b/lib/redfish_client/root.rb
@@ -2,6 +2,8 @@
 
 require "base64"
 require "json"
+require "server_sent_events"
+
 require "redfish_client/resource"
 
 module RedfishClient
@@ -60,6 +62,18 @@ module RedfishClient
     # @raise [NoResource] resource cannot be fetched
     def find!(oid)
       Resource.new(@connector, oid: oid)
+    end
+
+    # Return event listener.
+    #
+    # If the service does not support SSE, this function will return nil.
+    #
+    # @return [EventListener, nil] event listener
+    def event_listener
+      address = dig("EventService", "ServerSentEventUri")
+      return nil if address.nil?
+
+      EventListener.new(ServerSentEvents.create_client(address))
     end
 
     private

--- a/redfish_client.gemspec
+++ b/redfish_client.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.1"
 
   spec.add_runtime_dependency "excon", "~> 0.60"
+  spec.add_runtime_dependency "server_sent_events", "~> 0.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", ">= 11.0"

--- a/spec/redfish_client/event_listener_spec.rb
+++ b/spec/redfish_client/event_listener_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "json"
+require "server_sent_events/event"
+
+require "redfish_client/event_listener"
+
+RSpec.describe RedfishClient::EventListener do
+  context ".new" do
+    it "creates new instance" do
+      expect(described_class.new("http://sample.url"))
+        .to be_an_instance_of(described_class)
+    end
+  end
+
+  def new_event(records)
+    event = ServerSentEvents::Event.new
+    event.set("data", (records ? { "Events" => records } : {}).to_json)
+    event
+  end
+
+  context "#listen" do
+    let(:sse_client) { instance_double("ServerSentEvents::Client") }
+    let(:listener) { described_class.new(sse_client) }
+
+    it "splits event into records" do
+      records = [{ "a" => 3 }, { "b" => "c" }]
+      allow(sse_client).to receive(:listen).and_yield(new_event(records))
+
+      expect { |b| listener.listen(&b) }.to yield_successive_args(*records)
+    end
+
+    it "splits empty array of records" do
+      allow(sse_client).to receive(:listen).and_yield(new_event([]))
+
+      expect { |b| listener.listen(&b) }.not_to yield_control
+    end
+
+    it "handles missing event records" do
+      allow(sse_client).to receive(:listen).and_yield(new_event(nil))
+
+      expect { |b| listener.listen(&b) }.not_to yield_control
+    end
+  end
+end


### PR DESCRIPTION
Redfish events are collections of event records, which makes them a bit awkward to handle, since there is always this need for another nested loop.

This commit adds this nested loop inside the redfish client, so consumers of events now receive individual event records, already neatly parsed into individual hashes.