### PR TITLE
Add missing require statement to Redfish client

### DIFF
--- a/lib/redfish_client/root.rb
+++ b/lib/redfish_client/root.rb
@@ -4,6 +4,7 @@ require "base64"
 require "json"
 require "server_sent_events"
 
+require "redfish_client/event_listener"
 require "redfish_client/resource"
 
 module RedfishClient


### PR DESCRIPTION
Redfish client tried to instantiate event listener without properly requiring it first, which caused listener creation to fail with a missing constant message.