### PR TITLE
Properly handle absolute URLs in location header

### DIFF
--- a/lib/redfish_client/response.rb
+++ b/lib/redfish_client/response.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 module RedfishClient
   # Response struct.
   #
@@ -20,7 +22,10 @@ module RedfishClient
     end
 
     def monitor
-      done? ? nil : headers["location"]
+      return nil if done?
+
+      uri = URI.parse(headers["location"])
+      [uri.path, uri.query].compact.join("?")
     end
 
     def to_h

--- a/spec/redfish_client/response_spec.rb
+++ b/spec/redfish_client/response_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe RedfishClient::Response do
     it "returns nil on missing location header" do
       expect(described_class.new(200, {}, "b").monitor).to be_nil
     end
+
+    it "strips everything but path and query string from location header" do
+      url = "http://address:12345/path/?query=string"
+      expect(described_class.new(202, { "location" =>  url }, "b").monitor)
+        .to eq("/path/?query=string")
+    end
+
+    it "handles cases where query string is not present" do
+      url = "http://address:12345/path"
+      expect(described_class.new(202, { "location" =>  url }, "b").monitor)
+        .to eq("/path")
+    end
   end
 
   context "#status" do


### PR DESCRIPTION
Some servers might be configured to return absolute URLs in the location header. Because our client operates on paths only, we strip the redundant parts from the string and return path with optional
query parameter only.

Note that we do not handle any parse errors. This is done on purpose because we want to see a broken string in the application logs.