### PR TITLE
Bump excon version

### DIFF
--- a/redfish_client.gemspec
+++ b/redfish_client.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.1"
 
-  spec.add_runtime_dependency "excon", "~> 0.60"
+  spec.add_runtime_dependency "excon", "~> 0.71"
   spec.add_runtime_dependency "server_sent_events", "~> 0.1"
 
   spec.add_development_dependency "rake", ">= 11.0"


### PR DESCRIPTION
This should get rid of the https://github.com/advisories/GHSA-q58g-455p-8vw9