### PR TITLE
Save the session_id if returned in Location header

### DIFF
--- a/lib/redfish_client/connector.rb
+++ b/lib/redfish_client/connector.rb
@@ -230,10 +230,10 @@ module RedfishClient
       @session_oid = body["@odata.id"] if body.key?("@odata.id")
       return if @session_oid
 
-      if headers.key?(LOCATION_HEADER)
-        location = URI.parse(headers[LOCATION_HEADER])
-        @session_oid = [location.path, location.query].compact.join("?")
-      end
+      return unless headers.key?(LOCATION_HEADER)
+
+      location = URI.parse(headers[LOCATION_HEADER])
+      @session_oid = [location.path, location.query].compact.join("?")
     end
 
     def basic_login

--- a/lib/redfish_client/connector.rb
+++ b/lib/redfish_client/connector.rb
@@ -29,6 +29,7 @@ module RedfishClient
     # Basic and token authentication header names
     BASIC_AUTH_HEADER = "Authorization"
     TOKEN_AUTH_HEADER = "X-Auth-Token"
+    LOCATION_HEADER   = "Location"
 
     # Create new connector.
     #
@@ -218,9 +219,14 @@ module RedfishClient
       r = @connection.request(params)
       raise_invalid_auth_error unless r.status == 201
 
-      token = r.data[:headers][TOKEN_AUTH_HEADER]
+      headers = r.data[:headers]
+      body    = JSON.parse(r.data[:body])
+
+      token = headers[TOKEN_AUTH_HEADER]
       add_headers(TOKEN_AUTH_HEADER => token)
-      @session_oid = JSON.parse(r.data[:body])["@odata.id"]
+
+      @session_oid   = body["@odata.id"] if body.key?("@odata.id")
+      @session_oid ||= headers[LOCATION_HEADER]
     end
 
     def basic_login

--- a/spec/redfish_client/connector_spec.rb
+++ b/spec/redfish_client/connector_spec.rb
@@ -351,5 +351,23 @@ RSpec.describe RedfishClient::Connector do
 
       expect(stub).to have_been_requested
     end
+
+    it "removes valid location auth info from requests" do
+      stub_request(:post, "http://auth.demo/sessions")
+        .to_return(
+          body: { }.to_json,
+          headers: { "Location" => "/sessions/456" },
+          status: 201,
+        )
+      stub = stub_request(:delete, "http://auth.demo/sessions/456")
+        .to_return(status: 204)
+
+      connector = described_class.new("http://auth.demo")
+      connector.set_auth_info("user", "pass", "/test", "/sessions")
+      connector.login
+      connector.logout
+
+      expect(stub).to have_been_requested
+    end
   end
 end

--- a/spec/redfish_client/connector_spec.rb
+++ b/spec/redfish_client/connector_spec.rb
@@ -369,5 +369,23 @@ RSpec.describe RedfishClient::Connector do
 
       expect(stub).to have_been_requested
     end
+
+    it "removes url location auth info from requests" do
+      stub_request(:post, "http://auth.demo/sessions")
+        .to_return(
+          body: { }.to_json,
+          headers: { "Location" => "http://auth.demo/sessions/456" },
+          status: 201,
+        )
+      stub = stub_request(:delete, "http://auth.demo/sessions/456")
+        .to_return(status: 204)
+
+      connector = described_class.new("http://auth.demo")
+      connector.set_auth_info("user", "pass", "/test", "/sessions")
+      connector.login
+      connector.logout
+
+      expect(stub).to have_been_requested
+    end
   end
 end


### PR DESCRIPTION
If the `session_id` is returned in the `Location` header rather than the `@odata.id` in the body we should still save it so that it can be used for logout.

According to [Redfish Specification v1.10.0](https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.10.0.pdf) section `13.3.3.2. Session login` the response should look like:

> The response to the POST request to create a session shall include:
> • X-Auth-Token header. Contains a session authentication token that the client can use in subsequent requests.
> • Location header. Contains a hyperlink to the new Session resource.
> • JSON response body. Contains the full representation of the new Session resource.
>
> The following is a sample response of a session being created:

```
HTTP/1.1 201 Created
Location: /redfish/v1/SessionService/Sessions/1
X-Auth-Token: <session-auth-token>
{
  "@odata.id": "/redfish/v1/SessionService/Sessions/1",
  "@odata.type": "#Session.v1_0_0.Session",
  "Id": "1",
  "Name": "User Session",
  "Description": "User Session",
  "UserName": "<username>",
  "Password": null
}
```

If there isn't a `@odata.id` value in the body but there is a `Location` header we can use this value for the purpose of session logout according to `13.3.3.4. Session termination or logout`:

> The session terminates through a DELETE request to the Session resource defined in either the Location header URI or the session ID in the response data.

Fixes https://github.com/xlab-si/redfish-client-ruby/issues/32